### PR TITLE
Revert "Bump log from 0.4.11 to 0.4.12"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,11 +459,11 @@ checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
 
 [[package]]
 name = "log"
-version = "0.4.12"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3aeeb5dad71cdfb031ff8899db3e3e2bdcbc5abe7ad48e58857e42488dc4aa"
+checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ dotenv = "0.15.0"
 env_logger = "0.8.2"
 envy = "0.4.2"
 lazy_static = "1.4.0"
-log = "0.4.12"
+log = "0.4.11"
 regex = "1.4.2"
 reqwest = {version = "0.11.0", features = ["blocking", "json"]}
 serde = {version = "1.0.118", features = ["derive"]}


### PR DESCRIPTION
Reverts jonasbb/ctftimebot#883
log 0.4.12 is yanked from crates.io